### PR TITLE
Cleanup even when exception

### DIFF
--- a/cougarnet/virtualnet.py
+++ b/cougarnet/virtualnet.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import traceback
 
 
 MAC_RE = re.compile(r'^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$')
@@ -742,6 +743,8 @@ def main():
         net.message_loop()
     except KeyboardInterrupt:
         pass
+    except Exception:
+        traceback.print_exc()
     finally:
         net.cleanup()
 

--- a/cougarnet/virtualnet.py
+++ b/cougarnet/virtualnet.py
@@ -746,7 +746,10 @@ def main():
     except Exception:
         traceback.print_exc()
     finally:
-        net.cleanup()
+        try:
+            net.cleanup()
+        except Exception:
+            pass
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
When Cougarnet is stopped with a `KeyboardInterrupt`, the cleanup script is run. But when it crashes for some other reason, no cleanup is performed and the program just exits. This change prints a traceback, then tries to run as much of the cleanup as possible, then exits.