### PR TITLE
Add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ be installed next.
 To install Cougarnet, run the following:
 
 ```bash
+$ python3 -m pip install --user -r requirements.txt
 $ python3 setup.py build
 $ sudo python3 setup.py install
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+setuptools


### PR DESCRIPTION
This helps people figure out what is wrong when they try to run `setup.py`. If they don't have `setuptools`, the documentation will help them install it. I think `setuptools` comes with `pip`, but this will help people realize they don't have `pip` installed if that's the case and they are walking through the install instructions. This came up in Slack.