### PR TITLE
Check for other running instances of cougarnet before starting.

### DIFF
--- a/cougarnet/virtualnet.py
+++ b/cougarnet/virtualnet.py
@@ -736,7 +736,8 @@ def check_if_running(proc_name):
                 if not first_inst:
                     first_inst = True
                 else:
-                    raise AlreadyRunningError("Cougarnet is already running.")
+                    print("Cougarnet already running. Please cleanup the other instance before starting a new one.")
+                    raise AlreadyRunningError
         except psutil.NoSuchProcess:
             pass
 


### PR DESCRIPTION
I noticed that in some cases, Cougarnet would crash because another instance was already running (usually some leftover stuff when it had just crashed), and I needed to kill that before this run would work. This change adds a check for other running Cougarnet instances before starting, just to make sure that it's not going to error out from stepping on another instance's resources.

Note: We do need to make sure `psutil` is available before running this. This'll be easy if we just add it to `requirements.txt` (#6 )