### PR TITLE
Use Makefile for common commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: update build install install-deps
+
+build:
+	python3 setup.py build
+
+update:
+	git pull
+
+install:
+	sudo python3 setup.py install
+
+install-deps:
+	sudo apt install openvswitch-switch lxterminal python3-pygraphviz libgraph-easy-perl wireshark socat

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following are dependencies for Cougarnet:
 To install these on a Debian system, run the following:
 
 ```
-$ sudo apt install openvswitch-switch lxterminal python3-pygraphviz libgraph-easy-perl wireshark socat
+$ make install-deps
 ```
 
 Of course, this assumes that you already have `sudo` installed and that your user is
@@ -65,8 +65,7 @@ password (i.e., with the `NOPASSWD` option).
 To install Cougarnet, run the following:
 
 ```bash
-$ python3 setup.py build
-$ sudo python3 setup.py install
+$ make && make install
 ```
 
 


### PR DESCRIPTION
I like using `make`. I totally get it if you want to *not* use `make` to encourage more knowledge of what's going on, but if you like this solution, then here here's a PR that adds the ability to use `make`.

Instead of running three commands to update, build, and install, you can easily just run `make update && make && make install` and it should work just the same.