### PR TITLE
`pip` install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,19 @@ allowed to call it.
 Additionally, `sudo` should be configured such that your user can call it without requiring a
 password (i.e., with the `NOPASSWD` option).
 
-To install Cougarnet, run the following:
+To install a static copy of Cougarnet, run the following:
 
 ```bash
-$ python3 setup.py build
-$ sudo python3 setup.py install
+pip install .
 ```
+
+To install a Cougarnet in an easy-to-update manner, use the following:
+
+```bash
+pip install -e .
+```
+
+Then, when you want to update Cougarnet, just do a `git pull` and you are good to go!
 
 
 # Getting Started


### PR DESCRIPTION
This instruction set makes it much easier to manage installations and update Cougarnet. Specifically, the `-e` option to `pip` has helped me update Cougarnet on my system.

Feel free to use this or not, it's just made things easier for me and has solved a lot of my `PYTHONPATH` problems, etc. If you do end up going with this, I'd recommend updating the assignment repo to have everyone use `pip install -e` at first and then `git pull` for every update.